### PR TITLE
Update fastfetch.nix

### DIFF
--- a/modules/home/fastfetch.nix
+++ b/modules/home/fastfetch.nix
@@ -5,7 +5,7 @@
     enable = true;
     settings = {
     logo = {
-      source = "${config.home.homeDirectory}/hyprnix/resources/2b.txt";
+      source = builtins.toString ../../resources/2b.txt;
       padding = { top = 2; right = 6; };
     };
     display.separator = " ";


### PR DESCRIPTION
Use the relative path ../../resources/2b.txt resolved with `builtins.toString` instead of the bad absolute path `${config.home.homeDirectory}/hyprnix/resources/2b.txt`. This makes the configuration portable, allowing it to work regardless of the repository name or location.
