### PR TITLE
workspaces generate using nix code

### DIFF
--- a/modules/home/Nord/hypr.nix
+++ b/modules/home/Nord/hypr.nix
@@ -184,28 +184,6 @@ in {
         "SUPER, right, movefocus, r"
         "SUPER, up, movefocus, u"
         "SUPER, down, movefocus, d"
-        # Switch workspaces
-        "SUPER, 1, workspace, 1"
-        "SUPER, 2, workspace, 2"
-        "SUPER, 3, workspace, 3"
-        "SUPER, 4, workspace, 4"
-        "SUPER, 5, workspace, 5"
-        "SUPER, 6, workspace, 6"
-        "SUPER, 7, workspace, 7"
-        "SUPER, 8, workspace, 8"
-        "SUPER, 9, workspace, 9"
-        "SUPER, 0, workspace, 10"
-        # Move active window to a workspace
-        "SUPER SHIFT, 1, movetoworkspacesilent, 1"
-        "SUPER SHIFT, 2, movetoworkspacesilent, 2"
-        "SUPER SHIFT, 3, movetoworkspacesilent, 3"
-        "SUPER SHIFT, 4, movetoworkspacesilent, 4"
-        "SUPER SHIFT, 5, movetoworkspacesilent, 5"
-        "SUPER SHIFT, 6, movetoworkspacesilent, 6"
-        "SUPER SHIFT, 7, movetoworkspacesilent, 7"
-        "SUPER SHIFT, 8, movetoworkspacesilent, 8"
-        "SUPER SHIFT, 9, movetoworkspacesilent, 9"
-        "SUPER SHIFT, 0, movetoworkspacesilent, 10"
         # Move/resize windows
         "SUPER SHIFT, right, resizeactive, 50 0"
         "SUPER SHIFT, left, resizeactive, -50 0"
@@ -215,7 +193,19 @@ in {
         "SUPER CTRL, down, movewindow, d"
         "SUPER CTRL, left, movewindow, l"
         "SUPER CTRL, right, movewindow, r"
-      ];
+      ]
+      ++ (
+        # workspaces
+        # binds SUPER + [shift +] {1..9} to [move to] workspace {1..9}
+        builtins.concatLists (builtins.genList (i:
+            let ws = i + 1;
+            in [
+              "SUPER, code:1${toString i}, workspace, ${toString ws}"
+              "SUPER SHIFT, code:1${toString i}, movetoworkspacesilent, ${toString ws}"
+            ]
+          )
+          9)
+      );
 
       windowrulev2 = [
         "opacity 1 1,floating:1"


### PR DESCRIPTION
This PR refactors manual workspace keybindings into a more powerful and maintainable Nix expression using builtins.genList and builtins.concatLists.
